### PR TITLE
Fixed plate registration and processing

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -26,18 +26,23 @@ async def register_cmd(message: Message):
 @router.message()
 async def check_plate_mentions(message: types.Message):
     words = message.text.upper().split()
-    for word in words:
-        user_id = get_user_by_plate(word)
-#if user_id and user_id != message.from_user.id:
-        try:
-            await message.bot.send_message(
-                user_id,
-                f"🚗 Your plate **{word}** was mentioned in **{message.chat.title}**.\n"
-                f"[Jump to message](https://t.me/{message.chat.username}/{message.message_id})",
-                parse_mode="Markdown",
-                disable_web_page_preview=True
-            )
-        except Exception as e:
-            print(f"Error sending DM: {e}")  # Log errors if user hasn't started the bot
-
-
+    checked_plates = set()
+    for i in range(len(words)):
+        for j in range(i+1, min(i+4, len(words)+1)):
+            plate_candidate = ''.join(words[i:j])
+            plate_candidate = normalize_plate(plate_candidate)
+            if plate_candidate in checked_plates:
+                continue
+            checked_plates.add(plate_candidate)
+            user_id = get_user_by_plate(plate_candidate)
+            if user_id:
+                try:
+                    await message.bot.send_message(
+                        user_id,
+                        f"🚗 Your plate **{plate_candidate}** was mentioned in **{message.chat.title}**.\n"
+                        f"[Jump to message](https://t.me/{message.chat.username}/{message.message_id})",
+                        parse_mode="Markdown",
+                        disable_web_page_preview=True
+                    )
+                except Exception as e:
+                    print(f"Failed to send message to user {user_id}: {e}")


### PR DESCRIPTION
Previous implementation only checked individual words in messages for plate mentions. When someone writes "IEV 441" with a space, bot splits it into "IEV" and "441" and checks them separately. Since "IEV441" is registered as a single plate number, the bot doesn't recognize "IEV 441" as a match.

Modified check_plate_mentions function to consider combinations of adjacent words (up to three), joining and normalizing them to detect plate numbers mentioned with spaces.
Added a check to avoid redundant processing of the same plate candidates within a message.